### PR TITLE
Update Logux logo

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -368,7 +368,7 @@
               "title": "Logux",
               "author": "Andrey Sitnik",
               "url": "https://logux.org",
-              "icon": "https://logux.org/branding/logo-dark.svg"
+              "icon": "https://logux.org/branding/logo.svg"
             },
             {
               "title": "Loro",


### PR DESCRIPTION
SVG of Logux logo supports both light and dark theme (by inline `<style>` with media inside SVG file), so let’s use it.

Right now logo is broken in light theme.

<img width="524" height="252" alt="Captura desde 2025-08-04 17-57-49" src="https://github.com/user-attachments/assets/41b1ae30-ae45-49fc-96af-d73e630797c6" />

This solution is not 100% ideal since it will not work when user will switch theme manually. But I assume it is more rare case.