### PR TITLE
fix: remove discontinued projects from site

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -680,12 +680,6 @@
               "icon": "https://strut.io/favicon.ico"
             },
             {
-              "title": "Textorama",
-              "author": "João Melo",
-              "url": "https://textorama.melo.plus/",
-              "icon": "https://textorama.melo.plus/android-chrome-192x192.png"
-            },
-            {
               "title": "Tender",
               "author": "Tender team",
               "url": "https://tender.run/",

--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -855,20 +855,6 @@
         }
       },
       {
-        "id": 69,
-        "fields": {
-          "Main_Category": 1,
-          "Title": "Textorama",
-          "slug": "textorama",
-          "author": "João Melo",
-          "url": "https://textorama.melo.plus/",
-          "icon": "https://textorama.melo.plus/android-chrome-192x192.png",
-          "description": "Textorama is a modest text editor. It works with plain text files in your file system.",
-          "Categories": null,
-          "Uses": null
-        }
-      },
-      {
         "id": 71,
         "fields": {
           "Main_Category": 1,
@@ -949,20 +935,6 @@
           "icon": "https://noeldemartin.com/logos/umai-small.svg",
           "description": "A local-first recipe manager application.",
           "Categories": ["L", 37],
-          "Uses": null
-        }
-      },
-      {
-        "id": 78,
-        "fields": {
-          "Main_Category": 1,
-          "Title": "Calystone",
-          "slug": "calystone",
-          "author": "João Melo",
-          "url": "https://calyst.one/",
-          "icon": "https://calyst.one/icon.svg",
-          "description": "Calystone helps you organize your life through your file system with features like note taking and task management.",
-          "Categories": [2, 12, 37, 43],
           "Uses": null
         }
       },

--- a/static/search-index.json
+++ b/static/search-index.json
@@ -366,12 +366,6 @@
     "category": "Directory Entry"
   },
   {
-    "title": "Textorama",
-    "url": "/directory/apps/textorama",
-    "excerpt": "Textorama is a modest text editor. It works with plain text files in your file system.",
-    "category": "Directory Entry"
-  },
-  {
     "title": "Legend",
     "url": "/directory/apps/legend",
     "excerpt": "Legend is designed for you - to work the way you do and to be the one place for all your productivity needs.",
@@ -1041,12 +1035,6 @@
     "title": "Strut.io",
     "url": "https://strut.io",
     "excerpt": "Strut.io by Strut contributors",
-    "category": "Application"
-  },
-  {
-    "title": "Textorama",
-    "url": "https://textorama.melo.plus/",
-    "excerpt": "Textorama by João Melo",
     "category": "Application"
   },
   {


### PR DESCRIPTION
this PR removes two discontinued projects that are no long available: textorama and calystone.