### PR TITLE
Add BulkPicTools to content.json

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -703,7 +703,14 @@
                         "author": "Noel De Martin",
                         "url": "https://focus.noeldemartin.com",
                         "icon": "https://noeldemartin.com/logos/focus-small.svg"
-                    }
+                    },
+					{
+					    "title": "BulkPicTools",
+					    "author": "Genglin Zheng",
+					    "url": "https://bulkpictools.com",
+					    "icon": "https://bulkpictools.com/favicon.svg",
+					    "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+					}
                 ]
             }
         ]


### PR DESCRIPTION
Adding BulkPicTools to the directory. It's a privacy-focused image suite that handles all processing locally via WebAssembly. Fits the Lofi minimalism perfectly.