### PR TITLE
Add Runwita to Apps to try

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -716,6 +716,13 @@
                         "url": "https://bulkpictools.com",
                         "icon": "https://bulkpictools.com/favicon.svg",
                         "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+                    },
+                    {
+                        "title": "Runwita",
+                        "author": "Runwita",
+                        "url": "https://runwita.com",
+                        "icon": "https://runwita.com/favicon.png",
+                        "description": "Local-first Mac app for tracking long projects and customer relationships across many meetings, emails, and notes."
                     }
                 ]
             }


### PR DESCRIPTION
Adds Runwita to the **Apps to try** section.

**What it is:** Local-first Mac app for tracking long projects and customer relationships, the kind that play out over months across dozens of meetings, emails, and notes.

**Why local-first fits:**
- Data lives as a single SQLite file at \`~/Library/Application Support/Runwita/app.db\` on the user's Mac
- No cloud account required, no sync server, no telemetry
- The user owns the database file directly — they can copy it, back it up, or walk away from Runwita whenever
- AI extraction (on Pro/Believer) goes directly from the user's Mac to their own Anthropic or OpenAI key. Prompts never transit Runwita's infrastructure
- App is signed and notarised under an Apple Developer ID

Free tier available at https://runwita.com (one journey, ten engagements, AI extraction included for the trial).

Built solo. Happy to amend the description, the entry shape, or the icon if it doesn't fit your conventions.