### PR TITLE
Add tagst app

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -716,6 +716,13 @@
                         "url": "https://bulkpictools.com",
                         "icon": "https://bulkpictools.com/favicon.svg",
                         "description": "Privacy-first, 100% browser-side image suite for bulk processing, powered by WebAssembly."
+                    },
+					{
+                        "title": "Tagst",
+                        "author": "Tagst team",
+                        "url": "https://tagst.app/",
+                        "icon": "https://tagst.app/logo.svg",
+                        "description": "Bookmark and note manager built around tag chaining. Local-first, Privacy-first, no account required."
                     }
                 ]
             }


### PR DESCRIPTION
Add Tagst to the Apps to try.

**What it is:** Local-first pwa and browser-extension for managing bookmarks and notes with tags.

**Why local-first fits:**
Add Tagst to the Apps to try.

**What it is:** Local-first PWA and browser extension for managing bookmarks and notes with tag chaining.

**Why local-first fits:**
- No signup required, no tracking or ads
- Works offline, data lives in IndexedDB
- Optional sync with E2EE (passkey-only account)

more here https://tagst.app.

Thanks a lot.