### PR TITLE
docs: add AI Language Partner to directory

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "AI Language Partner",
+				"slug": "ai-language-partner",
+				"author": "duct-tape2 and contributors",
+				"url": "https://duct-tape2.github.io/ai-language-partner/demo/",
+				"icon": "https://duct-tape2.github.io/ai-language-partner/demo/favicon.ico",
+				"description": "An open-source local-first Japanese speaking practice app for Korean learners, using pre-authored dialogue banks and local STT/TTS with no runtime LLM dependency in the core conversation loop.",
+				"Categories": ["L", 37],
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
## What

Adds [AI Language Partner](https://github.com/duct-tape2/ai-language-partner), an open-source local-first Japanese speaking practice app for Korean learners.

The core conversation loop uses local STT/TTS and reviewed, pre-authored dialogue banks. It does not require a runtime LLM or hosted AI API.

## Validation

- JSON parses successfully; IDs and slugs remain unique
- project URL and favicon return HTTP 200
- `yarn prettier --check src/lib/data/directory/Item.json` passed
- `yarn check` passed with no errors
- `yarn build` passed

The repository-wide `yarn lint` currently hits an existing Prettier/Svelte plugin `getVisitorKeys` error; the changed JSON file itself passes Prettier.