### PR TITLE
Add SOP Builder to local-first directory

### DIFF
--- a/src/lib/data/directory/Item.json
+++ b/src/lib/data/directory/Item.json
@@ -993,6 +993,20 @@
 				"Categories": ["L", 40, 44],
 				"Uses": null
 			}
+		},
+		{
+			"id": 85,
+			"fields": {
+				"Main_Category": 1,
+				"Title": "SOP Builder",
+				"slug": "browser-sop-builder",
+				"author": "Mackanic Technologies",
+				"url": "https://max-agent-hub.github.io/browser-sop-builder/",
+				"icon": "https://max-agent-hub.github.io/browser-sop-builder/app-icon.svg",
+				"description": "Draft controlled SOPs locally in the browser and export them as Markdown. Works offline after the first visit, with no account, backend, analytics, or form-data storage.",
+				"Categories": ["L", 37],
+				"Uses": null
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- add Mackanic Technologies' open-source SOP Builder to the Apps directory
- categorize it as Open-Source
- link the live app and its same-origin icon

## Local-first fit

The static app processes form entries only in browser memory and has no account, backend, analytics, or form-data storage. A service worker caches only the public app shell, so the builder works offline after the first visit. Source: https://github.com/max-agent-hub/browser-sop-builder

## Verification

- `yarn check` (0 errors; existing repository warnings remain)
- `yarn build`
- JSON parse and unique ID/slug/title checks
- live app, icon, manifest, and offline reload verified