### PR TITLE
Add ResearchPocket to Apps to try

### DIFF
--- a/src/lib/data/content.json
+++ b/src/lib/data/content.json
@@ -718,6 +718,13 @@
                         "icon": "https://backwater.systems/finance/images/logo.256.png"
                     },
                     {
+                        "title": "ResearchPocket",
+                        "author": "ResearchPocket contributors",
+                        "url": "https://researchpocket.github.io/",
+                        "icon": "https://researchpocket.github.io/favicon.png",
+                        "description": "A local-first, URL-first personal research library for saving, enriching, curating, searching, and privately syncing useful links without a hosted account."
+                    },
+                    {
                         "title": "BulkPicTools",
                         "author": "Genglin Zheng",
                         "url": "https://bulkpictools.com",


### PR DESCRIPTION
## Summary

Adds [ResearchPocket](https://researchpocket.github.io/) to the Local-First Library's **Apps to try** list.

ResearchPocket is an open-source, local-first personal research library for saving, enriching, curating, searching, and privately syncing useful links without a hosted account.
